### PR TITLE
RuntimeError: Cannot add sibling to a node with no parent

### DIFF
--- a/app/services/embeddable_content/images/doc_processor.rb
+++ b/app/services/embeddable_content/images/doc_processor.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 module EmbeddableContent
   module Images
     class DocProcessor < EmbeddableContent::DocProcessor
       delegate :image_catalog, to: :embedder
+
+      CLASS_IMG_TAG_RELOCATED = 'img-tag-relocated-by-embedder'
 
       private
 
@@ -26,12 +30,19 @@ module EmbeddableContent
         img_tags_inside_p_tags.each do |img_tag|
           move_img_tag_out_from_p_tag img_tag
         end
+        remove_affected_empty_p_tags
+      end
+
+      def remove_affected_empty_p_tags
+        document.css("p.#{CLASS_IMG_TAG_RELOCATED}").each do |p_tag|
+          remove_if_empty p_tag
+        end
       end
 
       def move_img_tag_out_from_p_tag(img_tag)
         img_tag.parent.tap do |p_tag|
           p_tag.add_previous_sibling img_tag
-          remove_if_empty p_tag
+          p_tag.add_class CLASS_IMG_TAG_RELOCATED
         end
       end
 

--- a/lib/embeddable_content/version.rb
+++ b/lib/embeddable_content/version.rb
@@ -1,3 +1,3 @@
 module EmbeddableContent
-  VERSION = '0.1.8'.freeze
+  VERSION = '0.1.9'.freeze
 end


### PR DESCRIPTION
https://app.clubhouse.io/illustrative-mathematics/story/659/runtimeerror-cannot-add-sibling-to-a-node-with-no-parent

* FYI, github is reporting secuirty vulnerabilities. i have addressed those in my work on [this story](https://app.clubhouse.io/illustrative-mathematics/story/37/put-cc-image-captions-above-images) so will leave them alone here.