### PR TITLE
make embedder I18n aware

### DIFF
--- a/app/services/embeddable_content/embedder_base.rb
+++ b/app/services/embeddable_content/embedder_base.rb
@@ -35,6 +35,22 @@ module EmbeddableContent
                      self.class.default_s3_bucket
     end
 
+    def ed_node
+      @ed_node ||= options[:ed_node]
+    end
+
+    def tree_node
+      @tree_node ||= ed_node&.root
+    end
+
+    def tree
+      @tree ||= tree_node&.ref
+    end
+
+    def locale
+      @locale ||= tree&.locale
+    end
+
     private
 
     def module_name

--- a/app/services/embeddable_content/images/attributions_processor.rb
+++ b/app/services/embeddable_content/images/attributions_processor.rb
@@ -3,7 +3,8 @@ module EmbeddableContent
     class AttributionsProcessor
       attr_reader :image_processor
 
-      delegate :target, :document, :image_catalog, to: :image_processor
+      delegate :embedder, :target, :document, :image_catalog, to: :image_processor
+      delegate :locale, to: :embedder
 
       TARGETS_NEEDING_ATTRIBUTIONS = %i[print].freeze
       ATTRIBUTIONS_PARTIAL = 'export/shared/attributions_images'.freeze
@@ -41,6 +42,10 @@ module EmbeddableContent
       end
 
       def attributions_html
+        I18n.with_locale(locale) { render_html }
+      end
+
+      def render_html
         ApplicationController.renderer.render(
           partial: ATTRIBUTIONS_PARTIAL,
           locals:  { image_files: image_catalog }

--- a/app/services/embeddable_content/template_manager.rb
+++ b/app/services/embeddable_content/template_manager.rb
@@ -66,7 +66,7 @@ module EmbeddableContent
     end
 
     def render_target
-      render_path target_path
+      I18n.with_locale(locale) { render_path target_path }
     end
 
     def render_path(path)

--- a/app/services/embeddable_content/tree_based_node_processor.rb
+++ b/app/services/embeddable_content/tree_based_node_processor.rb
@@ -19,13 +19,5 @@ module EmbeddableContent
     def tree_embedder_tag_id
       tree_node&.embedder_tag_id
     end
-
-    def ed_node
-      @ed_node ||= options[:ed_node]
-    end
-
-    def tree_node
-      @tree_node ||= ed_node&.root
-    end
   end
 end

--- a/lib/embeddable_content/version.rb
+++ b/lib/embeddable_content/version.rb
@@ -1,3 +1,3 @@
 module EmbeddableContent
-  VERSION = '0.1.11'.freeze
+  VERSION = '0.1.12'.freeze
 end


### PR DESCRIPTION
Story details: https://app.clubhouse.io/illustrative-mathematics/story/792

* my staging app points to this branch of the gem
* per our discussion i modified the ES test tree to be kindergarten grade band
* i generated [the attached document](https://github.com/illustrativemathematics/embeddable_content/files/6496447/GdFf9O-TestCourse-1-Unit-student-workbook.pdf) on [this page](https://edc-cms-im.herokuapp.com/ed_nodes/259557/documents)
* the key change is [this line of code](https://github.com/illustrativemathematics/embeddable_content/compare/feature/ch792/make-embedder-i18n-aware?expand=1&title=make%20embedder%20I18n%20aware&body=Story%20details:%20https://app.clubhouse.io/illustrative-mathematics/story/792#diff-c31f1653d1b1a62f78fb6c37cff7b5cab200470add994bea5d86c91781debbc2R45)
* however on @dylandechant's suggestion i also modified [this line](https://github.com/illustrativemathematics/embeddable_content/compare/feature/ch792/make-embedder-i18n-aware?expand=1&title=make%20embedder%20I18n%20aware&body=Story%20details:%20https://app.clubhouse.io/illustrative-mathematics/story/792#diff-d239c763847e8ae7aedc8c62779141948e1d0f3a95e938c1363d33775e1fd3c9R69). 
  * this second edit makes future updates to embedder templates locale-aware
  * for instance, there is currently [static text in this template](https://github.com/illustrativemathematics/embeddable_content/blob/master/app/views/embeddable_content/replacements/video_links/_description.html.slim#L8-L10). with this second edit, text like this could include be made I18n-sensitive.
* the other changes in this commit serve to make the `locale` value, a field on the tree, visible to the annotations processor