### PR TITLE
remove expand image text from images

### DIFF
--- a/app/views/embeddable_content/replacements/images/_button_open.html.slim
+++ b/app/views/embeddable_content/replacements/images/_button_open.html.slim
@@ -7,4 +7,3 @@ ruby:
 button.im-c-button.im-c-modal-trigger data-modal-target = target_div_id
   p
     img src = asset_path('expand.png')
-    = trans :expand_image

--- a/lib/embeddable_content/version.rb
+++ b/lib/embeddable_content/version.rb
@@ -1,3 +1,3 @@
 module EmbeddableContent
-  VERSION = '0.1.14'.freeze
+  VERSION = '0.1.15'.freeze
 end


### PR DESCRIPTION
[ch 1507](https://app.clubhouse.io/illustrative-mathematics/story/1507/remove-embed-image-text-from-the-enlarge-image-feature) 
- removes expand image text from the enlarge image feature. 
- deployed to https://qa-kh-iiab.herokuapp.com/