### PR TITLE
Polynomial Math missing from PDF Exports

### DIFF
--- a/app/services/embeddable_content/tex/base_renderer.rb
+++ b/app/services/embeddable_content/tex/base_renderer.rb
@@ -2,31 +2,123 @@ require 'open3'
 
 module EmbeddableContent
   module Tex
+    class RenderError < StandardError
+      attr_reader :script, :stderr, :status
+
+      def initialize(script, stderr, status, api_errors)
+        @script = script
+        @stderr = stderr
+        @status = status
+        super "Unable to resolve error raised calling #{script}: #{status}\n#{stderr}\n#{api_errors}"
+      end
+    end
+
     class BaseRenderer
       RENDER_TEX_JS_PATH = Pathname.new('lib').join 'tasks/render_tex.js'
 
-      attr_reader :html
+      attr_reader :html, :stdout, :stderr, :status
 
       def initialize(html)
         @html = html
       end
 
       def render
-        html.replace render_format(target_format) if target_format.present?
+        return html unless rendering_required?
+
+        run_script
       end
 
       private
 
-      def render_format(format)
-        output, status = Open3.capture2(render_tex(format), stdin_data: html)
-        return output if status.success?
-
-        Rails.logger.warn "Error calling #{render_tex(format)}: #{status}"
-        html
+      def rendering_required?
+        not_yet_rendered? && target_format.present?
       end
 
-      def render_tex(format)
-        [RENDER_TEX_JS_PATH, '--output', format].join(' ')
+      def not_yet_rendered?
+        status.blank?
+      end
+
+      def render_failed?
+        failed_status || stderr.present?
+      end
+
+      def failed_status
+        status.present? && !status.success?
+      end
+
+      def render_error
+        @render_error ||= RenderError.new script, stderr, status, api_errors
+      end
+
+      def run_script
+        @run_script ||= Open3.capture3(script, stdin_data: html).tap do |stdout, stderr, status|
+          @stdout = stdout
+          @stderr = stderr
+          @status = status
+        end
+        render_failed? ? try_api_client : html.replace(stdout)
+      end
+
+      def script
+        @script ||= [RENDER_TEX_JS_PATH, '--output', target_format].join(' ')
+      end
+
+      REGEX_TEX_STRING = /Formula\s+(?<texstring>.*)\s+contains the following errors:/.freeze
+      def offending_tex_string
+        @offending_tex_string ||= REGEX_TEX_STRING.match(stderr)[:texstring].strip if
+          stderr.present?
+      end
+
+      def document
+        @document ||= Nokogiri::HTML html
+      end
+
+      def all_spans
+        @all_spans ||= document.css 'span'
+      end
+
+      def api_errors
+        offending_node.blank? ? '' : api_client.errors.unshift('API errors:').join("\n")
+      end
+
+      def try_api_client
+        raise render_error if offending_node.blank?
+        raise render_error unless api_client.success?
+
+        offending_node.content = ''
+        offending_node.add_child repaired_content
+        renderer_for_repaired_document.render
+      end
+
+      def renderer_for_repaired_document
+        @renderer_for_repaired_document ||=
+          self.class.new html.replace(document.to_html)
+      end
+
+      def repaired_span
+        @repaired_span = %w[<span class="mathjax-api"></span>].tap do |span|
+          span << repaired_content
+        end
+      end
+
+      def repaired_content
+        @repaired_content ||= api_client.send target_format
+      end
+
+      def api_client
+        @api_client ||= Mathjax::Api::Client.new offending_tex_string
+      end
+
+      def offending_node
+        @offending_node ||=
+          all_spans.detect { |node| offending_tex_appears_in?(node) }
+      end
+
+      REGEX_NODE_TEX_CONTENT = /\\\(\s*(?<tex_string>.*)\s*\\\)/m.freeze
+      def offending_tex_appears_in?(node)
+        node.content.match(REGEX_NODE_TEX_CONTENT).then do |md|
+          md.present? && md[:tex_string]&.strip.eql?(offending_tex_string)
+        end
       end
     end
   end

--- a/app/services/embeddable_content/tex/canvas_renderer.rb
+++ b/app/services/embeddable_content/tex/canvas_renderer.rb
@@ -7,8 +7,8 @@ module EmbeddableContent
         :canvas
       end
 
-      def render_format(_format)
-        Mathjax::CanvasRenderer.new(html).render
+      def render
+        html.replace Mathjax::CanvasRenderer.new(html).render
       end
     end
   end

--- a/app/services/mathjax/api/client.rb
+++ b/app/services/mathjax/api/client.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Mathjax
+  module Api
+    class Client; end
+  end
+end

--- a/lib/embeddable_content/version.rb
+++ b/lib/embeddable_content/version.rb
@@ -1,3 +1,3 @@
 module EmbeddableContent
-  VERSION = '0.1.19'.freeze
+  VERSION = '0.2.0'.freeze
 end


### PR DESCRIPTION
https://app.shortcut.com/illustrative-mathematics/story/3120/polynomial-math-missing-from-pdf-exports

# overview
## background
1. the embedder shells out to a node script that relies on mjnode-page.
2. the mjnode-page library parses HTML and typesets any TeX expressions in place, replacing them with SVG or TeX+CSS or whatever. 
3. the mjnode-page library simply plows through any typesetting errors. it pipes warnings to STDERR but does not return a nonzero status code. all i had been checking in the embedder was the process status code (not STDERR) so this went undetected; the embedder raises on exception on a nonzero status codes from the node script
4. the structure that has been failing (for who knows how long?) looks like this (TeX comments are my own):
```
<span class="math math-displayed math-repaired">
\(\displaystyle 
\require{enclose}  % hook into MML specials; see MathJax docs for more. 
  \begin{array}{r}  x^2+4x+3 \\ 
   x+1 \enclose{longdiv}{x^3+5x^2+7x+3} \\    
   \underline{\text-x^3-x^2} \phantom{+7x+333} \\  
   4x^2+7x \phantom{+33}\\ 
   \underline{\text-4x^2-4x} \phantom{+33} \\ 3x+3 \\ 
   \underline{\text-3x-3} 
   \\ 0 
\end{array}\)
</span>
```
* the above snippet comes from the student lesson summary of [this lesson](https://edc-cms-im.herokuapp.com/ed_nodes/43213/lessons/2018/edit)
* i suspect the non-standard `\enclose` macro underlies the problem we're seeing. AFAIKT the intent is to allow direct interaction with MathML from TeX. you can read about it in the [MathJax docs](http://docs.mathjax.org/en/latest/input/tex/extensions/enclose.html). 

## my fix
1. the embedder runs the script [as before](https://github.com/illustrativemathematics/embeddable_content/compare/bug/sc-3120/polynomial-math-missing-from-pdf-exports?expand=1#diff-f243c7a2e415174124a4ba3f3da8d922b83a63255aeb23fad5b32ac8e4a3090bR59), only now i take care to capture STDERR.
2. if there is no failure, the embedder returns the HTML as updated by the script.
3. if there *is* a failure, as indicated by a nonzero status code OR (crucially) a nonblank STDERR, then:
  * i inspect the STDERR for the bad tex expression. in the above quoted TeX, the STDERR looks something like:
  ```
Formula  \require{enclose}\begin{array}{r}  x^2+4x+3 \\ x+1 \enclose{longdiv}{x^3+5x^2+7x+3} \\    \underline{\text-x^3-x^2} \phantom{+7x+333} \\  4x^2+7x \phantom{+33}\\ \underline{\text-4x^2-4x} \phantom{+33} \\ 3x+3 \\ \underline{\text-3x-3} \\ 0 \end{array} contains the following errors:
 [ 'Math Processing Error: svg.getBBox is not a function' ]
  ```
  * i use a regex to extract the TeX 
  * i then traverse the *original* dom (not the dom for the script return value) to find a span containing this TeX.
    * i can't use the return value of the script since the script removes the offending TeX; this makes it impossible to find which node to repair using the API
  * i submit the TeX to the API and then replace the offending span with the return value.
  * i then re-run the embedder processor on the updated page. 
  * note that this process can take several passes. e.g. for the above linked lesson it takes 3 passes.
    * it would be better if i processed all of the errors in the STDERR --- the script wouldn't need to run again each time. this would avoid recursion. but i didn't think about this superior design until i started writing these notes.
