### PR TITLE
remove hardcoded link to asset now gone in the cms repo

### DIFF
--- a/app/assets/javascripts/geogebra/support.js
+++ b/app/assets/javascripts/geogebra/support.js
@@ -9,6 +9,5 @@ function loadGeogebraApplet(elmt) {
       dataNode   = elmt.getElementsByClassName('ggb-base-64-data')[0],
       parameters = JSON.parse(dataNode.dataset['parameters']),
       applet     = new GGBApplet(parameters, '5.0');
-  applet.setHTML5Codebase('/GeoGebra/HTML5/5.0/web3d/');
   applet.inject(container.id);
 };

--- a/lib/embeddable_content/version.rb
+++ b/lib/embeddable_content/version.rb
@@ -1,3 +1,3 @@
 module EmbeddableContent
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end


### PR DESCRIPTION
this change removes the hardcoded value for Geogebra's `HTML5Codebase`, which defaults it back to the newly supplied cdn location:

![image](https://user-images.githubusercontent.com/5204375/223561651-22136e15-9e8e-47f6-8bb6-868a750782b5.png)
