### PR TITLE
update embeddable_content

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,26 @@ and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 Bug reports and pull requests are welcome on GitHub at
 https://github.com/illustrativemathematics/embeddable_content.
+
+## Notes
+
+To update a version of this gem:
+1. Update version number in `lib/embeddable_content/version.rb`.
+2. Run:
+
+``` bash
+$ gem build embeddable_content.gemspec
+```
+3. A new gem file will be created,
+   e.g. `embeddable_content-0.2.0.gem`. Run:
+
+``` bash
+$ gem push embeddable_content-0.2.0.gem
+```
+
+## Versions
+
+| Version | Changes                                                                                                       |
+| ---     | ---                                                                                                           |
+| 0.3.1   | Meaningless change as I (EDC) experiment with gem host.                                                       |
+| 0.2.0   | NIMAS export now using embedder for TeX. However, the embedder is not yet using the full TexExprssions table. |

--- a/embeddable_content.gemspec
+++ b/embeddable_content.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |spec|
   # To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section
   # to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against ' \
-      'public gem pushes.'
-  end
+  # if spec.respond_to?(:metadata)
+  #   spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+  # else
+  #   raise 'RubyGems 2.0 or newer is required to protect against ' \
+  #     'public gem pushes.'
+  # end
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/lib/embeddable_content/version.rb
+++ b/lib/embeddable_content/version.rb
@@ -1,3 +1,3 @@
 module EmbeddableContent
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.3.1'.freeze
 end


### PR DESCRIPTION
https://app.shortcut.com/illustrative-mathematics/story/7594/update-embeddable-content

this restores gem version 3.1 from rubygems

* i downloaded the gem from [rubygems](https://rubygems.org/gems/embeddable_content/versions/0.3.1)
* i unpacked it:
```
$ gem unpack embeddable_content-0.3.1.gem
```
* i copied the unpacked files into the repo. the delta is what you see here.