### PR TITLE
Move exports to use CDN Url instead of time-boxed service url for S3 objects

### DIFF
--- a/app/services/embeddable_content/images/img_tag_attributes.rb
+++ b/app/services/embeddable_content/images/img_tag_attributes.rb
@@ -28,7 +28,7 @@ module EmbeddableContent
         when :cms                     then cms_url
         when :editable                then downloaded_file_url
         when :exported, :qti          then s3_url with_extension: false
-        when :print, :web             then s3_ttl_url
+        when :print, :web             then record.cdn_url
         end
       end
 

--- a/lib/embeddable_content/version.rb
+++ b/lib/embeddable_content/version.rb
@@ -1,3 +1,3 @@
 module EmbeddableContent
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.1.0'.freeze
 end


### PR DESCRIPTION


https://linear.app/illustrativemathematics/issue/INF-48/move-exports-to-use-cdn-url-instead-of-time-boxed-service-url-for-s3